### PR TITLE
Скрыта частота слов в статистике

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -6,7 +6,7 @@ type Word struct {
 	Word string  `json:"word"`
 	TF   float64 `json:"tf"`
 	IDF  float64 `json:"idf" `
-	Freq int     `json:"frequency"`
+	Freq int     `json:"-"`
 }
 
 // Metrics represents application metrics for processing files.


### PR DESCRIPTION
Незначительное изменение структуры Word в файле internal/model/model.go. Поле Freq теперь исключено из сериализации JSON путем замены его тега `json` на `"-"`